### PR TITLE
Fix Header Links

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -10,6 +10,10 @@
 }
 
 .custom-header-links {
+  a {
+    color: currentColor;
+  }
+
   .top-level-links {
     list-style: none;
     display: flex;

--- a/javascripts/discourse/components/custom-header-dropdown.gjs
+++ b/javascripts/discourse/components/custom-header-dropdown.gjs
@@ -29,7 +29,11 @@ export default class CustomHeaderDropdown extends Component {
       {{on "click" (fn this.redirectToUrl @item.url)}}
     >
       <CustomIcon @icon={{@item.icon}} />
-      <span class="custom-header-link-title">{{@item.title}}</span>
+      {{#if @item.url}}
+        <a href={{@item.url}} class="custom-header-link-title">{{@item.title}}</a>
+      {{else}}
+        <span class="custom-header-link-title">{{@item.title}}</span>
+      {{/if}}
       {{#if @item.description}}
         <span class="custom-header-link-desc">{{@item.description}}</span>
       {{/if}}

--- a/javascripts/discourse/components/custom-header-dropdown.gjs
+++ b/javascripts/discourse/components/custom-header-dropdown.gjs
@@ -16,7 +16,11 @@ export default class CustomHeaderDropdown extends Component {
       this.toggleHeaderLinks();
     }
 
-    DiscourseURL.routeTo(url);
+    const regex = new RegExp(`^${this.router.rootURL}`);
+    if (regex.test(url)) {
+      event.preventDefault();
+      DiscourseURL.routeTo(url);
+    }
 
     event.stopPropagation();
   }

--- a/javascripts/discourse/components/custom-header-link.gjs
+++ b/javascripts/discourse/components/custom-header-link.gjs
@@ -87,7 +87,11 @@ export default class CustomHeaderLink extends Component {
         )}}
       >
         <CustomIcon @icon={{@item.icon}} />
-        <span class="custom-header-link-title">{{@item.title}}</span>
+        {{#if @item.url}}
+          <a href={{@item.url}} class="custom-header-link-title">{{@item.title}}</a>
+        {{else}}
+          <span class="custom-header-link-title">{{@item.title}}</span>
+        {{/if}}
 
         {{#if this.showCaret}}
           <span class="custom-header-link-caret">

--- a/javascripts/discourse/components/custom-header-link.gjs
+++ b/javascripts/discourse/components/custom-header-link.gjs
@@ -14,6 +14,7 @@ export default class CustomHeaderLink extends Component {
   @service siteSettings;
   @service site;
   @service currentUser;
+  @service router;
 
   @notEmpty("dropdownLinks") hasDropdown;
 
@@ -65,12 +66,18 @@ export default class CustomHeaderLink extends Component {
   }
 
   @action
-  redirectToUrl(url) {
+  redirectToUrl(url, event) {
     if (this.site.mobileView) {
       this.toggleHeaderLinks();
     }
 
-    DiscourseURL.routeTo(url);
+    const regex = new RegExp(`^${this.router.rootURL}`);
+    if (regex.test(url)) {
+      event.preventDefault();
+      DiscourseURL.routeTo(url);
+    }
+
+    event.stopPropagation();
   }
 
   <template>


### PR DESCRIPTION
- Render an `<a>` tag if header item has a url. This allows items to be open like normal links (ex. right click then open link in new tab)
- Set the color of anchor tags so it will inherit the colors defined in the plugin settings
- Use Discourse routing if the relative url matches the `rootURL`.

Reported via [Community](https://www.sitepoint.com/community/t/question/460598) 